### PR TITLE
Don't aggregate L2 errors with L3 errors for physical ports with RIF

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -360,19 +360,8 @@ class InterfacesUpdater(MIBUpdater):
 
     def aggregate_counters(self):
         """
-        For ports with l3 router interfaces l3 drops may be counted separately (RIF counters)
-        add l3 drops to l2 drop counters cache according to mapping
-
         For l3vlan map l3 counters to l2 counters
         """
-        for rif_sai_id, port_sai_id in self.rif_port_map.items():
-            if port_sai_id in self.if_id_map:
-                port_idx = mibs.get_index_from_str(self.if_id_map[port_sai_id])
-                for port_counter_name, rif_counter_name in mibs.RIF_DROPS_AGGR_MAP.items():
-                    self.if_counters[port_idx][port_counter_name] = \
-                    self.if_counters[port_idx].get(port_counter_name, 0) + \
-                    self.rif_counters[rif_sai_id].get(rif_counter_name, 0)
-
         for vlan_sai_id, vlan_name in self.vlan_name_map.items():
             for port_counter_name, rif_counter_name in mibs.RIF_COUNTERS_AGGR_MAP.items():
                 vlan_idx = mibs.get_index_from_str(vlan_name)

--- a/tests/namespace/test_interfaces.py
+++ b/tests/namespace/test_interfaces.py
@@ -466,7 +466,7 @@ class TestGetNextPDU_1213(TestCase):
 
     def test_in_errors_rif(self):
         """
-        For a port with RIF the counter values are aggregated
+        For a port with RIF the counter values are not aggregated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 9))
         get_pdu = GetPDU(
@@ -480,7 +480,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 9))))
-        self.assertEqual(value0.data, 101)
+        self.assertEqual(value0.data, 100)
 
     def test_out_octets_rif(self):
         """
@@ -520,7 +520,7 @@ class TestGetNextPDU_1213(TestCase):
 
     def test_out_errors_rif(self):
         """
-        For a port with RIF the counter values are aggregated
+        For a port with RIF the counter values are not aggregated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 9))
         get_pdu = GetPDU(
@@ -534,7 +534,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 9))))
-        self.assertEqual(value0.data, 102)
+        self.assertEqual(value0.data, 100)
 
     def test_in_octets_vlan(self):
         """
@@ -682,7 +682,7 @@ class TestGetNextPDU_1213(TestCase):
 
     def test_in_errors_vlan_subinterface(self):
         """
-        For a port with multiple vlan subinterfaces (RIF) all RIF drops are accumulated
+        For a port with multiple vlan subinterfaces (RIF) all RIF drops are not accumulated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 17))
         get_pdu = GetPDU(
@@ -696,7 +696,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 17))))
-        self.assertEqual(value0.data, 203)
+        self.assertEqual(value0.data, 0)
 
     def test_out_octets_vlan_subinterface(self):
         """
@@ -736,7 +736,7 @@ class TestGetNextPDU_1213(TestCase):
 
     def test_out_errors_vlan_subinterface(self):
         """
-        For a port with multiple vlan subinterfaces (RIF) all RIF drops are accumulated
+        For a port with multiple vlan subinterfaces (RIF) all RIF drops are not accumulated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 17))
         get_pdu = GetPDU(
@@ -750,7 +750,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 17))))
-        self.assertEqual(value0.data, 203)
+        self.assertEqual(value0.data, 0)
 
     def test_in_octets_portchannel(self):
         """

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -461,7 +461,7 @@ class TestGetNextPDU(TestCase):
 
     def test_in_errors_rif(self):
         """
-        For a port with RIF the counter values are aggregated
+        For a port with RIF the counter values are not aggregated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 21))
         get_pdu = GetPDU(
@@ -475,7 +475,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 21))))
-        self.assertEqual(value0.data, 101)
+        self.assertEqual(value0.data, 100)
 
     def test_out_octets_rif(self):
         """
@@ -515,7 +515,7 @@ class TestGetNextPDU(TestCase):
 
     def test_out_errors_rif(self):
         """
-        For a port with RIF the counter values are aggregated
+        For a port with RIF the counter values are not aggregated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 21))
         get_pdu = GetPDU(
@@ -529,7 +529,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 21))))
-        self.assertEqual(value0.data, 102)
+        self.assertEqual(value0.data, 100)
 
     def test_in_octets_vlan(self):
         """
@@ -677,7 +677,7 @@ class TestGetNextPDU(TestCase):
 
     def test_in_errors_vlan_subinterface(self):
         """
-        For a port with multiple vlan subinterfaces (RIF) all RIF drops are accumulated
+        For a port with multiple vlan subinterfaces (RIF) all RIF drops are not accumulated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 9))
         get_pdu = GetPDU(
@@ -691,7 +691,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 14, 9))))
-        self.assertEqual(value0.data, 203)
+        self.assertEqual(value0.data, 0)
 
     def test_out_octets_vlan_subinterface(self):
         """
@@ -731,7 +731,7 @@ class TestGetNextPDU(TestCase):
 
     def test_out_errors_vlan_subinterface(self):
         """
-        For a port with multiple vlan subinterfaces (RIF) all RIF drops are accumulated
+        For a port with multiple vlan subinterfaces (RIF) all RIF drops are not accumulated
         """
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 9))
         get_pdu = GetPDU(
@@ -745,7 +745,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.COUNTER_32)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 20, 9))))
-        self.assertEqual(value0.data, 203)
+        self.assertEqual(value0.data, 0)
 
     def test_in_octets_portchannel(self):
         """


### PR DESCRIPTION
<!--
Please make sure you've read and understood our contributing guidelines;
https://github.com/Azure/SONiC/blob/gh-pages/CONTRIBUTING.md

** Make sure all your commits include a signature generated with `git commit -s` **

If this is a bug fix, make sure your description includes "fixes #xxxx", or
"closes #xxxx"

Please provide the following information:
-->

**- What I did**

**- How I did it**

**- How to verify it**

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->

